### PR TITLE
Bump libpython-clj

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,11 +2,7 @@
         io.github.inferenceql/inferenceql.inference {:git/sha "e1dcd0f2721dcdef388f8270dc9bd80eecde3ef9"}
         medley/medley {:mvn/version "1.3.0"}}
 
- :aliases {;; https://github.com/clj-python/libpython-clj/issues/180#issuecomment-949993210
-           :jdk-17 {:jvm-opts ["--add-modules" "jdk.incubator.foreign"
-                               "--enable-native-access=ALL-UNNAMED"]}
-
-           :test {:extra-paths ["test/src"
+ :aliases {:test {:extra-paths ["test/src"
                                 "test/resources"]
                   :extra-deps {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}
                                org.clojure/test.check {:mvn/version "0.10.0"}}


### PR DESCRIPTION
## Overview

- Bump libpython-clj to take advantage of [a bugfix](https://github.com/clj-python/libpython-clj/issues/212#issuecomment-1373732374).
- Remove an alias that provided a workaround for the bug.